### PR TITLE
Update page layout in vignette

### DIFF
--- a/pkg/vignettes/using_tinytest.Rnw
+++ b/pkg/vignettes/using_tinytest.Rnw
@@ -3,12 +3,12 @@
 \usepackage{enumitem}
 \setlist{nosep}
 
-% simpler, but issue with your margin notes \usepackage[margin=1in]{geometry}
+% simpler, but issue with your margin notes
+% \usepackage[margin=1in]{geometry}
 \usepackage{vmargin}
 \setpapersize{USletter} % or a4 for you
-%  Left Top Right Bottom
 % Left Top Right Bottom headheight?? headsep footheight footsep
-\setmarginsrb{0.75in}{0.25in}{1.1in}{0.35in}{15pt}{15pt}{10pt}{20pt}
+\setmarginsrb{0.75in}{0.25in}{1.1in}{0.25in}{15pt}{0pt}{10pt}{20pt}
 
 \usepackage{hyperref}
 

--- a/pkg/vignettes/using_tinytest.Rnw
+++ b/pkg/vignettes/using_tinytest.Rnw
@@ -3,6 +3,13 @@
 \usepackage{enumitem}
 \setlist{nosep}
 
+% simpler, but issue with your margin notes \usepackage[margin=1in]{geometry}
+\usepackage{vmargin}
+\setpapersize{USletter} % or a4 for you
+%  Left Top Right Bottom
+% Left Top Right Bottom headheight?? headsep footheight footsep
+\setmarginsrb{0.75in}{0.25in}{1.1in}{0.35in}{15pt}{15pt}{10pt}{20pt}
+
 \usepackage{hyperref}
 
 \hypersetup{
@@ -14,7 +21,6 @@
 }
 
 \renewcommand{\familydefault}{\sfdefault}
-
 
 \title{Using tinytest}
 \author{Mark van der Loo}
@@ -42,7 +48,9 @@
 
 \tableofcontents{}
 <<echo=FALSE>>=
-options(prompt="R>  ", continue = "    ")
+options(prompt="R>  ",
+        continue = "    ",
+        width=75)
 @
 
 
@@ -150,7 +158,7 @@ print them in long format (default) or in short, one-line format like so.
 <<>>=
 print(expect_equal(1+1, 3), type="short")
 @
-\marginpar{\scriptsize{\code{print} method}}
+\marginpar{\scriptsize \code{print} method}
 Functions that run multiple tests return an object of class \code{tinytests}
 (notice the plural). Since there may be a lot of test results, \pkg{tinytest}
 tries to be smart about printing them. The user has ultimate control over
@@ -180,7 +188,7 @@ checks. An example test file in tinytest can look like this.
     expect_equal(addOne(hihi), 2)
 \end{verbatim}
 
-A particular file can be run using\marginpar{\scriptsize\code{run\_test\_file}}
+A particular file can be run using\marginpar{\scriptsize \code{run\_test\_file}}
 <<eval>>=
 run_test_file("test_addOne.R", verbose=FALSE)
 @
@@ -206,7 +214,8 @@ options(tt.pr.passes=TRUE)
 @
 to print all results during the active R session.
 
-To run all test files in a certain directory, we can use\marginpar{\code{run\_test\_dir}}
+To run all test files in a certain directory, we can
+use\marginpar{\scriptsize \code{run\_test\_dir}}
 <<eval=FALSE>>=
 run_test_dir("/path/to/your/test/directory")
 @
@@ -220,14 +229,14 @@ out <- run_test_dir(system.file("tinytest", package="tinytest")
        , verbose=FALSE)
 @
 The results can be turned into data using \code{as.data.frame}.
-\marginpar{\scriptsize{\code{as.data.frame}}}
+\marginpar{\scriptsize \code{as.data.frame}}
 <<>>=
 head(as.data.frame(out), 3)
 @
 The last two columns indicate the line numbers where the test was defined.
 
 A `summary` of the output gives a table with passes and fails per file.
-\marginpar{\scriptsize{\code{summary}}}
+\marginpar{\scriptsize \code{summary}}
 <<>>=
 summary(out)
 @
@@ -251,7 +260,7 @@ will be caught in the test output, when this is run with \code{run\_test\_file}
 \code{R CMD check} using \code{test\_package}.
 
 If you want to perform the test, but not record the test result you can do the
-following \marginpar{\code{ignore}} (note the placement of the brackets).
+following \marginpar{\scriptsize \code{ignore}} (note the placement of the brackets).
 <<eval=TRUE>>=
 if ( ignore(expect_equal)(1+1, 2) ){
   expect_true(2>0)
@@ -314,7 +323,7 @@ names starting with \code{test} (for example \code{test\_haha.R}).
 \item In your \code{DESCRIPTION} file, add \pkg{tinytest} to \code{Suggests:}.
 \end{enumerate}
 You can automatically create a minimal running test infrastructure
-with the \code{setup\_tinytest} function. \marginpar{\code{setup\_tinytest}}
+with the \code{setup\_tinytest} function. \marginpar{\scriptsize \code{setup\_tinytest}}
 <<eval=FALSE>>=
 setup_tinytest("/path/to/your/package")
 @
@@ -328,7 +337,7 @@ and all tests will run.
 
 
 To run all the tests interactively, make sure that all functions of your 
-new package are loaded. After that, run\marginpar{\code{test\_all}}
+new package are loaded. After that, run\marginpar{\scriptsize \code{test\_all}}
 <<eval=FALSE>>=
 test_all("/path/to/your/package")
 @


### PR DESCRIPTION
You can fiddle with the `setmarginsrb` param -- that ends up being some trial and error.  It's an older package I used  "forever", these days I don't use it much directly as I work more from markdown with already set styles (_e.g._ in [pinp](https://github.com/eddelbuettel/pinp) for vignettes) .

But it looks a little more 'filled' to me now with a better ink/paper ratio.