### PR TITLE
tinytest namespace is unlikely to be loaded

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -776,7 +776,7 @@ at_home <- function(){
 #' # Create a file with the following content, to use
 #' # tinytest as your unit testing framework:
 #'   if (requireNamespace("tinytest", quietly=TRUE))
-#'     test_package("your package name")
+#'     tinytest::test_package("your package name")
 #' }
 #' @export
 test_package <- function(pkgname, testdir = "tinytest"


### PR DESCRIPTION
Noticed minor thing, probably a result of `require` used in the past. Now when there is `requireNamespace` it is unlikely that tinytest namespace will be attached, thus prefix is needed.