### PR TITLE
fix default pattern in build_install_test()

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -959,7 +959,7 @@ test_package <- function(pkgname, testdir = "tinytest"
 #' @family test-files
 #' @export
 build_install_test <- function(pkgdir="./", testdir="tinytest"
-                             , pattern="test_.+[rR]$"
+                             , pattern="^test.*\\.[rR]$"
                              , at_home=TRUE
                              , verbose=getOption("tt.verbose",2)
                              , ncpu = 1


### PR DESCRIPTION
The previous default file pattern for `build_install_test()` (added in https://github.com/markvanderloo/tinytest/commit/c1e4418e025384ce979ebfb4d66d432754fe1bd8) would search for "test_" in the filename, so for example excluded a `test-function.R` script, although the documentation says the default means to include R scripts *starting* with "test" (no underscore!):
https://github.com/markvanderloo/tinytest/blob/e7da8ebdf8498daea71ad871ea4a4db8aa031623/pkg/R/tinytest.R#L933-L935