### PR TITLE
avoid truncation of test failures

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -908,9 +908,8 @@ test_package <- function(pkgname, testdir = "tinytest"
   out <- run_test_dir(testdir, at_home=at_home, cluster=cluster,...) 
   i_fail <- sapply(out, isFALSE)
   if ( any(i_fail) && !interactive() ){
-    msg <- paste( sapply(out[i_fail], format.tinytest, type="long"), collapse="\n")
-    msg <- paste(msg, "\n")
-    stop(msg, call.=FALSE)
+    writeLines(vapply(out[i_fail], format.tinytest, "", type="long"))
+    stop(sum(i_fail), " out of ", length(out), " tests failed", call.=FALSE)
   } 
   out
 }


### PR DESCRIPTION
The previous approach could result in an incomplete report as error messages are subject to truncation, by default at 1000 chars (see `getOption("warning.length")`.

This patch ensures that all failures are included in the test output (Rout file).
The final error message only gives the number of failed tests.
R CMD check will show the last few lines of the output in the log as usual.