### PR TITLE
Do not start exit_file message with linebreak, add a space at end

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -93,9 +93,9 @@ output <- function(){
   e$exit_msg <- function(print){
     if(print){ 
       plural <- e$lst != e$fst
-      if (plural) catf("\nExited '%s' at lines %d-%d. %s"
+      if (plural) catf("Exited '%s' at lines %d-%d. %s "
                      , basename(e$file), e$fst, e$lst, e$exitmsg)
-      else catf("\nExited '%s' at line %d. %s"
+      else catf("Exited '%s' at line %d. %s "
               , basename(e$file), e$fst, e$exitmsg)
     }
   }


### PR DESCRIPTION
I took a quick look at this and it is indeed simple.  As you said, users can still stick `\n` into their messages but for me this is much cleaner and more compact.  Withness Rcpp with one of the two needed toggles set and the other still complaining at times (and ignore the measurements, I had just run and we now see the very nice effects of `ccache` pulling down compile times):  

![image](https://user-images.githubusercontent.com/673121/99452731-93f91e00-28e9-11eb-934d-71b8cb22d0c1.png)
