### PR TITLE
classed errors/warnings are only available in R >= 3.6.0

### DIFF
--- a/pkg/inst/tinytest/test_tiny.R
+++ b/pkg/inst/tinytest/test_tiny.R
@@ -58,15 +58,17 @@ expect_equal(women, dat)
 expect_warning(warning("foo"))
 expect_error(stop("bar"))
 
-# class of error condition
-ec <- errorCondition(message="wa babalooba", class="foo")
-expect_false(ignore(expect_error)( stop(ec), class="bar" ))
-expect_true (ignore(expect_error)( stop(ec), class="foo" ))
+if (getRversion() >= "3.6.0") {
+  # class of error condition
+  ec <- errorCondition(message="wa babalooba", class="foo")
+  expect_false(ignore(expect_error)( stop(ec), class="bar"))
+  expect_true (ignore(expect_error)( stop(ec), class="foo"))
 
-# class of warning condition
-wc <- warningCondition(message="ba la bamboo", class="foo")
-expect_false(ignore(expect_warning)( warning(wc), class="bar"))
-expect_true (ignore(expect_warning)( warning(wc), class="foo"))
+  # class of warning condition
+  wc <- warningCondition(message="ba la bamboo", class="foo")
+  expect_false(ignore(expect_warning)( warning(wc), class="bar"))
+  expect_true (ignore(expect_warning)( warning(wc), class="foo"))
+}
 
 # messages to stdout
 expect_stdout(print("hihi"))


### PR DESCRIPTION
This small change lets **tinytest** successfully pass R CMD check in R < 3.6.0 (actually only for R >= 3.2.0, see #77).