### PR TITLE
Actually use quietly

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -308,7 +308,7 @@ add_locally_masked_functions <- function(envir, output){
 #' @export
 using <- function(package, quietly=TRUE){
   pkg <- as.character(substitute(package))
-  if ( !require(pkg, quietly=TRUE, character.only=TRUE) ){
+  if ( !require(pkg, quietly=quietly, character.only=TRUE) ){
     stopf("Package %s could not be loaded",pkg)
   }
   ext <- getOption("tt.extensions", FALSE)


### PR DESCRIPTION
In `using(package, quietly = TRUE)`, the argument `quietly` is advertised as being passed to `require` yet does not actually do so.