### PR TITLE
Support RStudio addins

### DIFF
--- a/pkg/inst/rstudio/addins.dcf
+++ b/pkg/inst/rstudio/addins.dcf
@@ -1,0 +1,3 @@
+Name: Run all tests in a directory
+Binding: test_all
+Interactive: false


### PR DESCRIPTION
Hi! Thanks for this great package! With our package, we support anything from R-3.0.0 and `testthat` requires too recent versions of R (not `testthat` itself, but many of its bizar number of dependencies).

So your package is most welcome. Since we use RStudio for development, we liked the Shift+Ctrl/Cmd+L option to run all unit tests. To assign keyboard shortcuts, RStudio requires an 'addins' file in the `inst/` folder. This very subtle pull request adds a shortcut to `tinytest::test_all()` to RStudio:

<img width="337" alt="image" src="https://user-images.githubusercontent.com/31037261/118365730-5cb8b080-b59e-11eb-9934-31d3296cf225.png">

Allowing:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/31037261/118365884-ca64dc80-b59e-11eb-9cde-3809a198cf24.png">
