### PR TITLE
Support R < 3.2

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -22,7 +22,7 @@ Description: Provides a lightweight (zero-dependency) and easy to use
 Version: 1.2.4.9
 URL: https://github.com/markvanderloo/tinytest
 BugReports: https://github.com/markvanderloo/tinytest/issues
-Depends: R (>= 3.2.0)
+Depends: R (>= 3.0.0)
 Imports: parallel, utils
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -7,9 +7,10 @@ msgf  <- function(fmt, ...) message(sprintf(fmt,...))
 
 # support R versions < 3.2, that lack trimws()
 trimws <- function (x, which = c("both", "left", "right"), whitespace = "[ \t\r\n]") {
-    which <- match.arg(which)
-    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
-    switch(which, left = mysub(paste0("^", whitespace, "+"), 
-        x), right = mysub(paste0(whitespace, "+$"), x), both = mysub(paste0(whitespace, 
-        "+$"), mysub(paste0("^", whitespace, "+"), x)))
+  which <- match.arg(which)
+  mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+  switch(which,
+         left = mysub(paste0("^", whitespace, "+"), x),
+         right = mysub(paste0(whitespace, "+$"), x),
+         both = mysub(paste0(whitespace, "+$"), mysub(paste0("^", whitespace, "+"), x)))
 }

--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -5,6 +5,13 @@ stopf <- function(fmt,...) stop(sprintf(fmt,...), call.=FALSE)
 warnf <- function(fmt,...) warning(sprintf(fmt,...), call.=FALSE)
 msgf  <- function(fmt, ...) message(sprintf(fmt,...))
 
-
-
-
+# support R < 3.2, that lacks trimws()
+trimws <- function(x, which = c("both", "left", "right")) {
+  which <- match.arg(which)
+  mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+  if (which == "left")
+    return(mysub("^[ \t\r\n]+", x))
+  if (which == "right")
+    return(mysub("[ \t\r\n]+$", x))
+  mysub
+}

--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -5,13 +5,11 @@ stopf <- function(fmt,...) stop(sprintf(fmt,...), call.=FALSE)
 warnf <- function(fmt,...) warning(sprintf(fmt,...), call.=FALSE)
 msgf  <- function(fmt, ...) message(sprintf(fmt,...))
 
-# support R < 3.2, that lacks trimws()
-trimws <- function(x, which = c("both", "left", "right")) {
-  which <- match.arg(which)
-  mysub <- function(re, x) sub(re, "", x, perl = TRUE)
-  if (which == "left")
-    return(mysub("^[ \t\r\n]+", x))
-  if (which == "right")
-    return(mysub("[ \t\r\n]+$", x))
-  mysub
+# support R versions < 3.2, that lack trimws()
+trimws <- function (x, which = c("both", "left", "right"), whitespace = "[ \t\r\n]") {
+    which <- match.arg(which)
+    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+    switch(which, left = mysub(paste0("^", whitespace, "+"), 
+        x), right = mysub(paste0(whitespace, "+$"), x), both = mysub(paste0(whitespace, 
+        "+$"), mysub(paste0("^", whitespace, "+"), x)))
 }

--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -5,7 +5,7 @@ stopf <- function(fmt,...) stop(sprintf(fmt,...), call.=FALSE)
 warnf <- function(fmt,...) warning(sprintf(fmt,...), call.=FALSE)
 msgf  <- function(fmt, ...) message(sprintf(fmt,...))
 
-# support R versions < 3.2, that lack trimws()
+# support R versions < 3.2, that lack trimws() and dir.exists()
 trimws <- function (x, which = c("both", "left", "right"), whitespace = "[ \t\r\n]") {
   which <- match.arg(which)
   mysub <- function(re, x) sub(re, "", x, perl = TRUE)
@@ -13,4 +13,8 @@ trimws <- function (x, which = c("both", "left", "right"), whitespace = "[ \t\r\
          left = mysub(paste0("^", whitespace, "+"), x),
          right = mysub(paste0(whitespace, "+$"), x),
          both = mysub(paste0(whitespace, "+$"), mysub(paste0("^", whitespace, "+"), x)))
+}
+dir.exists <- function (paths) {
+  x = base::file.info(paths)$isdir
+  !is.na(x) & x
 }


### PR DESCRIPTION
This line in your `init.R` uses `trimws()`:

https://github.com/markvanderloo/tinytest/blob/6ccbd9af4499ee9a46d2db0c5e160cb5eae766e3/pkg/R/init.R#L5

Unfortunately, this functions was only added in R-3.2, which makes this package unable to load in all versions of R-3.0 and R-3.1. This is a pity, since it's otherwise dependency free! 

With this fix, users can test their package against older R versions.