### PR TITLE
build_install_test: use fields in read.dcf to explicitely read the package name

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -1086,7 +1086,7 @@ build_install_test <- function(pkgdir="./", testdir="tinytest"
 
   pkg <- normalizePath(pkgdir, winslash="/")
 
-  pkgname <- read.dcf(file.path(pkg, "DESCRIPTION"))[1]
+  pkgname <- read.dcf(file.path(pkg, "DESCRIPTION"), fields = "Package")
 
   pattern <- gsub("\\", "\\\\", pattern, fixed=TRUE)
 


### PR DESCRIPTION
Hi,

just stumbled across this, as I tried to use `build_install_test` on a package with a `DESCRIPTION` file being formatted like this:
```
Type: Package
Package: jap
Title: Just another package
Version: 0.0.1
...
```

Running `tinytest::build_install_test()` locally resulted in the following error:
```
> tinytest::build_install_test()
* checking for file ‘/home/christoph/packages/jap/DESCRIPTION’ ... OK
* preparing ‘jap’:
* checking DESCRIPTION meta-information ... OK
* cleaning src
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* building ‘jap_0.0.1.tar.gz’

Error in library(pkgname, lib.loc = tdir, character.only = TRUE) : 
  there is no package called ‘Package’
Calls: suppressPackageStartupMessages -> withCallingHandlers -> library
Execution halted
Warning in gzfile(file, "rb") :
  cannot open compressed file '/tmp/RtmplJlFgQ/file37c317b5bbcf/output.RDS', probable reason 'No such file or directory'
Error in gzfile(file, "rb") : cannot open the connection
Backtrace:
    █
 1. └─tinytest::build_install_test()
 2.   └─base::readRDS(file.path(tdir, "output.RDS"))
 3.     └─base::gzfile(file, "rb")
```
I know that the `Type` field in the `DESCRIPTION` file is [optional](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Package-types). But if it is listed on top, `pkgname <- read.dcf(file.path(pkg, "DESCRIPTION"))[1]`, just returns `Package`.

To make this more robust, I suggest to rather make use of the `fields` argument in `read.dcf` for querying the package name.





