### PR TITLE
bugfix: using multiple extension packages

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -362,7 +362,7 @@ using <- function(package, quietly=TRUE){
   } else {
     ext
   }
-  names(out) <- pkg
+  if (length(out) == 1) names(out) <- pkg
   invisible(out)
 }
 
@@ -372,22 +372,24 @@ capture_using <- function(fun, envir, output){
     ext <- fun(...)
     
     # get package name
-    pkg <- names(ext)
-    functions <- ext[[pkg]]
+    pkgs <- names(ext)
 
-    for ( func in functions ){ # get funcy!
-      # get function object from namespace
-      f <- tryCatch(getFromNamespace(func, pkg)
-          , error = function(e){
-              msg <- sprintf("Loading '%s' extensions failed with message:\n'%s'"
-                            , pkg, e$message)
-              warning(msg, call.=FALSE)
-            })
-
-      # mask'm like there's no tomorrow 
-      envir[[func]] <- capture(f, output)
-      
+    for ( pkg in pkgs ){
+      functions <- ext[[pkg]]
+      for ( func in functions ){ # get funcy!
+        # get function object from namespace
+        f <- tryCatch(getFromNamespace(func, pkg)
+            , error = function(e){
+                msg <- sprintf("Loading '%s' extensions failed with message:\n'%s'"
+                              , pkg, e$message)
+                warning(msg, call.=FALSE)
+              })
+  
+        # mask'm like there's no tomorrow 
+        envir[[func]] <- capture(f, output)
+      }
     }
+
     invisible(ext)
   }
 }


### PR DESCRIPTION
This PR is a proposed fix for the bug reported here: https://github.com/markvanderloo/tinytest/issues/101

The problem arises when users to try to register multiple extension packages with `using()`. In the Issue linked above, I tried to register the `checkmate` extension, as well as my (experimental) `tinyviztest` package.

When multiple extension packages are registered, `getOption("tt.extensions", FALSE)` returns a named list of functions, with names corresponding to the extension package names.

These two code blocks assume that there is only one element in this list:

* https://github.com/markvanderloo/tinytest/blob/master/pkg/R/tinytest.R#L375
* https://github.com/markvanderloo/tinytest/blob/master/pkg/R/tinytest.R#L365

When two or more extension packages are registered, `getOption("tt.extensions")` returns a list with two elements, which results in an indexing error:

```r
[1] "tinyviztest" NA
Error in ext[[pkg]] : subscript out of bounds
Calls: run_test_dir -> lapply -> FUN -> eval -> eval -> using
```

Note that this error only arises when I call `run_test_file()`, not when I execute the tests interactively.
