### PR TITLE
Fix for R >=4 (scalar conditional expressions

### DIFF
--- a/pkg/R/expectations.R
+++ b/pkg/R/expectations.R
@@ -618,7 +618,7 @@ expect_warning <- function(current, pattern=".*"
  
  
   results <- sapply(warnings, function(w) {
-    inherits(w, class) && grepl(pattern, w$message, ...)
+    inherits(w, class) && any(grepl(pattern, w$message, ...), na.rm = TRUE)
   })
 
   if (any(results)){ ## happy flow


### PR DESCRIPTION
This fixes an error in our GitHub Action:

```
  Error in inherits(w, class) && grepl(pattern, w$message, ...) : 
    'length = 3' in coercion to 'logical(1)'
  Calls: test_package ... eval -> expect_warning -> fun -> sapply -> lapply -> FUN
  Execution halted
```

Your `grepl()` may yield length > 1 (3 in my case), while `inherits()` never does. That's illegal in recent R versions when using `&&` or `||` (either side must be length 1). This should fix it.