### PR TITLE
Switch to https URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CRAN](http://www.r-pkg.org/badges/version/tinytest)](http://cran.r-project.org/package=tinytest/)
+[![CRAN](https://www.r-pkg.org/badges/version/tinytest)](https://cran.r-project.org/package=tinytest/)
 [![status](https://tinyverse.netlify.app/badge/tinytest)](https://CRAN.R-project.org/package=tinytest)
-[![Downloads](http://cranlogs.r-pkg.org/badges/tinytest)](http://cran.r-project.org/package=tinytest/)
+[![Downloads](https://cranlogs.r-pkg.org/badges/tinytest)](https://cran.r-project.org/package=tinytest/)
 
 
 # tinytest <img src="img/logo_tinytest.png" width="150" align="right" alt="tinytest has no logo" />
@@ -103,7 +103,7 @@ Of course, printing is configurable through options.
 
 ### Light weight is the right weight
 
-Keep it simple, keep it clean. See  [tinyverse.org](http://www.tinyverse.org).
+Keep it simple, keep it clean. See  [tinyverse.org](https://www.tinyverse.org).
 
 
 


### PR DESCRIPTION
Minor maintenance commit here -- I noticed that in (some, old) README.md of mine old badges still using http:// were not rendering, and that was also the case in the `tinytest` checkout I had. As it seemed to be the same problem 'upstream' here I made a quick PR.  It also updates the reference to [tinyverse.org](https://www.tinyverse.org).

