### PR TITLE
Use a more robust path for R

### DIFF
--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -1132,7 +1132,13 @@ build_install_test <- function(pkgdir="./", testdir="tinytest"
   setwd(tdir)
 
   ## build package
-  system2("R", args=c("CMD", "build", "--no-build-vignettes", "--no-manual", shQuote(pkg)))
+  if(.Platform$OS.type == "windows") {
+      system2(file.path(R.home("bin"), "Rterm.exe")
+              , args=c("CMD", "build", "--no-build-vignettes", "--no-manual", shQuote(pkg)))
+  } else {
+      system2(file.path(R.home("bin"), "R")
+              , args=c("CMD", "build", "--no-build-vignettes", "--no-manual", shQuote(pkg)))
+  }
 
 
   ## find tar.gz and install in temporary folder.
@@ -1198,7 +1204,11 @@ if (!is.null(cluster)) parallel::stopCluster(cluster)
         , encoding)
 
   write(scr, file="test.R")
-  system("Rscript test.R")
+  if(.Platform$OS.type == "windows") {
+      system2(file.path(R.home("bin"), "Rscript.exe"), args="test.R")
+  } else {
+      system2(file.path(R.home("bin"), "Rscript"), args="test.R")
+  }
 
   readRDS(file.path(tdir, "output.RDS"))
 


### PR DESCRIPTION
This ensure that the version of R called matches the one you are in. Mainly relevant when you have multiple versions of R installed (e.g. R and R-devel).

I've not yet tested the windows command yet (no access) so marking as draft for now.