### PR TITLE
Update documentation for exit_if_not()

### DIFF
--- a/pkg/NEWS
+++ b/pkg/NEWS
@@ -18,7 +18,7 @@ version 1.4.1
   (Thanks to Joshua Ulrich for the suggestion)
 - New function 'expect_length' checks length of object (thanks to Marcel Ramos 
   for suggesting).
-- New function 'exit_if': conditionally exit a test file, akin to stopifnot.
+- New function 'exit_if_not': conditionally exit a test file, akin to stopifnot.
   (Thanks to Grant McDermott for triggering this).
 - New function 'expect_match' to test whether string output(s) match a 
   regular expression (Thanks to Aaron Jacobs for the suggestion).

--- a/pkg/R/tinytest.R
+++ b/pkg/R/tinytest.R
@@ -185,7 +185,7 @@ ignore <- function(fun){
 #' Stop testing (conditionally)
 #'
 #' Use \code{exit_file} to exit a file with a custom message, or use
-#' \code{exit_if} to exit if one or more conditions are met. \code{exit_if}
+#' \code{exit_if_not} to exit if one or more conditions are not met. \code{exit_if_not}
 #' will create a message akin to messages created by \code{\link[base]{stopifnot}}.
 #'
 #' @param msg \code{[character]} An optional message to print after exiting.


### PR DESCRIPTION
The function exit_if() does not exist. exit_if_not() exits if any of the conditions it is passed evaluate to a non-TRUE value.

Follow-up to https://github.com/markvanderloo/tinytest/commit/592ccf2c75c00bc83a41e617f2d91dbd1520b755. AFAICT the function `exit_if()` never existed.